### PR TITLE
feat: add workflow skills and design pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Designer Skills
+
+This is a collection of 63 design skills organized into a pipeline that mirrors professional design practice. Skills can be used independently for focused work or chained together through commands and workflow skills.
+
+## Design Pipeline
+
+The natural progression for greenfield projects:
+
+1. **Research** (design-research) - Understand users and context
+2. **Strategy** (ux-strategy) - Frame the problem and define direction
+3. **Systems** (design-systems) - Establish tokens and components
+4. **UI + Interaction** (ui-design, interaction-design) - Design screens and flows
+5. **Prototyping & Testing** (prototyping-testing) - Validate decisions
+6. **Ops & Delivery** (design-ops, designer-toolkit) - Handoff, rationale, case studies
+
+Use the `design-pipeline` skill for guided end-to-end workflow with quality gates between phases.
+
+## Quick Start
+
+- `/discover` - Start with user research
+- `/strategize` - Define UX strategy
+- `/design-screen` - Design a screen layout
+- `/evaluate` - Run a heuristic evaluation
+- `/handoff` - Create a developer handoff package
+
+## Skills
+
+All 63 skills are loaded automatically. Use the `skill` tool to list available skills or load a specific one. Each skill is a standalone unit of domain expertise that can be used independently.
+
+## How It Works
+
+When working on design tasks, check if any of the 63 skills apply before responding. The `using-designer-skills` skill (injected at session start) provides a complete index of all skills organized by pipeline phase.
+
+For focused work, load individual skills directly. For multi-skill workflows, use commands (type `/` to see available commands). For full projects, use the `design-pipeline` skill.

--- a/workflow/skills/design-pipeline/SKILL.md
+++ b/workflow/skills/design-pipeline/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: design-pipeline
+description: Use when working on a greenfield design project that needs the full design process from research through delivery with quality gates between phases
+---
+
+# Design Pipeline
+
+A guided workflow for taking a design project from research through delivery. This skill orchestrates individual design skills into a coherent pipeline with quality gates between phases.
+
+<HARD-GATE>
+Do NOT skip phases without explicit user approval. Present phase outputs and get confirmation before proceeding to the next phase. The user may choose to skip phases, but that must be their decision.
+</HARD-GATE>
+
+## When to Use
+
+- Starting a new product or feature from scratch
+- The user wants a structured end-to-end design process
+- You need to ensure thorough coverage of design concerns
+
+Do NOT use when:
+- The user wants a specific, focused task (use individual skills)
+- The user is entering mid-process (start at the appropriate phase)
+
+## Checklist
+
+You MUST create a todo for each phase and complete them in order:
+
+1. **Scope the project** — Understand what's being designed, for whom, and constraints
+2. **Research Phase** — Understand users and context
+3. **Strategy Phase** — Frame the problem and define direction
+4. **Systems Phase** — Establish design foundations
+5. **Design Phase** — Design screens, interactions, and flows
+6. **Validation Phase** — Test and validate decisions
+7. **Delivery Phase** — Hand off and document
+
+## Process Flow
+
+```dot
+digraph pipeline {
+    "Scope Project" [shape=box];
+    "Research" [shape=box];
+    "Approve research?" [shape=diamond];
+    "Strategy" [shape=box];
+    "Approve strategy?" [shape=diamond];
+    "Systems" [shape=box];
+    "Approve systems?" [shape=diamond];
+    "Design" [shape=box];
+    "Approve design?" [shape=diamond];
+    "Validation" [shape=box];
+    "Issues found?" [shape=diamond];
+    "Delivery" [shape=box];
+    "Done" [shape=doublecircle];
+
+    "Scope Project" -> "Research";
+    "Research" -> "Approve research?";
+    "Approve research?" -> "Research" [label="revise"];
+    "Approve research?" -> "Strategy" [label="approve"];
+    "Strategy" -> "Approve strategy?";
+    "Approve strategy?" -> "Strategy" [label="revise"];
+    "Approve strategy?" -> "Systems" [label="approve"];
+    "Systems" -> "Approve systems?";
+    "Approve systems?" -> "Systems" [label="revise"];
+    "Approve systems?" -> "Design" [label="approve"];
+    "Design" -> "Approve design?";
+    "Approve design?" -> "Design" [label="revise"];
+    "Approve design?" -> "Validation" [label="approve"];
+    "Validation" -> "Issues found?";
+    "Issues found?" -> "Design" [label="critical issues"];
+    "Issues found?" -> "Delivery" [label="approved"];
+    "Delivery" -> "Done";
+}
+```
+
+## Phase 0: Scope the Project
+
+Before entering the pipeline, understand the project:
+
+1. **What** is being designed? (Product, feature, redesign?)
+2. **Who** are the users? (Any existing research?)
+3. **Why** now? (Business driver, user pain, opportunity?)
+4. **Constraints** — timeline, technology, brand, accessibility requirements
+5. **Existing assets** — any research, designs, systems already in place?
+
+Based on the answers, determine which phases to include. A project with existing research may skip Phase 1. A project with an established design system may skip Phase 3.
+
+**Gate:** Confirm the pipeline scope with the user before proceeding.
+
+---
+
+## Phase 1: Research
+
+**Goal:** Understand who you're designing for and what their experience looks like today.
+
+Load and execute these skills in sequence:
+1. `user-persona` — Create 2-4 personas from available data
+2. `empathy-map` — Build empathy maps for the primary persona
+3. `journey-map` — Map the end-to-end journey for the primary persona
+
+**If research data is sparse:**
+- Use `interview-script` to prepare scripts for gathering data
+- Use `jobs-to-be-done` to map user motivations from available information
+
+**Gate:** Present a research summary with:
+- Key personas (prioritized)
+- Primary empathy map
+- Journey map with pain points highlighted
+- Top 3-5 design implications
+
+Get user approval before proceeding to Strategy.
+
+---
+
+## Phase 2: Strategy
+
+**Goal:** Frame the problem, understand the landscape, and define direction.
+
+Load and execute these skills in sequence:
+1. `competitive-analysis` — Analyze 3-5 competitor approaches
+2. `north-star-vision` — Articulate the product vision
+3. `design-principles` — Define 4-6 guiding principles
+4. `opportunity-framework` — Identify and prioritize opportunities
+5. `metrics-definition` — Define 3-5 success measures
+6. `design-brief` — Consolidate into a brief
+
+**Gate:** Present the strategy document with:
+- Competitive landscape summary
+- North-star vision statement
+- Design principles
+- Prioritized opportunity list
+- Success metrics
+- Design brief
+
+Get user approval before proceeding to Systems.
+
+---
+
+## Phase 3: Systems
+
+**Goal:** Establish the design foundations — tokens, naming, core components.
+
+Load and execute these skills in sequence:
+1. `design-token` — Define the token system (color, spacing, typography, elevation)
+2. `naming-convention` — Establish naming rules for tokens and components
+3. `component-spec` — Spec the core components needed for the project
+
+**If building on an existing system:**
+- Use `design-token-audit` to assess current token coverage
+- Use `accessibility-audit` to check existing components
+
+**Gate:** Present the systems foundation with:
+- Token system overview (categories, tiers, naming)
+- Core component list with specs
+- Naming convention rules
+
+Get user approval before proceeding to Design.
+
+---
+
+## Phase 4: Design
+
+**Goal:** Design the actual screens, interactions, and flows.
+
+Load and execute skills based on what the project needs:
+
+**Visual Design:**
+1. `layout-grid` — Define the grid system
+2. `visual-hierarchy` — Establish hierarchy for key screens
+3. `typography-scale` — Apply the type system
+4. `color-system` — Apply the color system
+5. `spacing-system` — Apply spacing rules
+6. `responsive-design` — Define responsive behavior
+7. `dark-mode-design` — If applicable
+
+**Interaction Design:**
+8. `state-machine` — Model complex component interactions
+9. `micro-interaction-spec` — Specify key micro-interactions
+10. `feedback-patterns` — Define system feedback
+11. `error-handling-ux` — Design error handling
+12. `loading-states` — Design loading patterns
+
+Not every skill is needed for every project. Use judgment based on the project scope.
+
+**Gate:** Present the design specifications with:
+- Key screen layouts with annotations
+- Responsive behavior summary
+- Interaction specifications for complex components
+- Error handling approach
+
+Get user approval before proceeding to Validation.
+
+---
+
+## Phase 5: Validation
+
+**Goal:** Test and validate design decisions before delivery.
+
+Load and execute these skills:
+1. `heuristic-evaluation` — Expert review against Nielsen's 10 heuristics
+2. `accessibility-audit` — WCAG 2.2 AA compliance check
+
+**If user testing is planned:**
+3. `usability-test-plan` — Design the test plan
+4. `test-scenario` — Write specific test tasks
+
+**Gate:** Present validation findings with:
+- Heuristic evaluation results (issues by severity)
+- Accessibility compliance status
+- Remediation recommendations
+
+If **critical issues** are found, return to Phase 4 to address them before proceeding.
+If **minor issues** are found, document them for the delivery phase.
+Get user approval before proceeding to Delivery.
+
+---
+
+## Phase 6: Delivery
+
+**Goal:** Package the design for implementation.
+
+Load and execute these skills:
+1. `handoff-spec` — Create developer handoff specifications
+2. `design-qa-checklist` — Create implementation QA checklist
+3. `design-rationale` — Document key design decisions
+
+**Output:** Complete handoff package with:
+- Visual and interaction specifications
+- Asset list
+- QA checklist
+- Design rationale document
+- Known issues from validation (with severity)
+
+---
+
+## Key Principles
+
+- **Gates are mandatory** — Do not proceed without user approval at each gate
+- **Phases can be skipped** — If the user says "skip research," respect it
+- **Iteration is expected** — Validation findings often send you back to Design
+- **Each phase builds on the previous** — Reference earlier outputs, don't repeat work
+- **Track progress** — Use TodoWrite to track phase and step completion
+- **Stay focused** — Not every skill is needed for every project; use judgment
+- **Suggest but don't force** — The pipeline is a guide, not a prison

--- a/workflow/skills/using-designer-skills/SKILL.md
+++ b/workflow/skills/using-designer-skills/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: using-designer-skills
+description: Use when starting any design session - establishes the design pipeline, available skills, and how to route design work through the right skills
+---
+
+# Using Designer Skills
+
+You have access to a comprehensive collection of **63 design skills** organized into a pipeline that mirrors professional design practice. Each skill is a standalone unit of domain expertise. Skills can be used independently or chained together through commands and workflow skills.
+
+## The Design Pipeline
+
+Skills are organized into 6 phases. Use them independently for focused work, or follow the pipeline for greenfield projects:
+
+### Phase 1: Research (design-research)
+Understand users and context.
+- `user-persona` — Create user personas from research data
+- `empathy-map` — Build empathy maps for user understanding
+- `journey-map` — Map end-to-end user journeys
+- `interview-script` — Prepare structured interview scripts
+- `summarize-interview` — Extract insights from interview transcripts
+- `usability-test-plan` — Design usability test plans
+- `card-sort-analysis` — Analyze card sorting results
+- `diary-study-plan` — Plan diary studies
+- `affinity-diagram` — Organize research data into themes
+- `jobs-to-be-done` — Map user motivations and outcomes
+
+**Commands:** `/discover`, `/interview`, `/synthesize`, `/research-test-plan`
+
+### Phase 2: Strategy (ux-strategy)
+Frame the problem and define direction.
+- `north-star-vision` — Articulate product vision
+- `competitive-analysis` — Analyze competitor UX
+- `experience-map` — Map the full touchpoint ecosystem
+- `design-principles` — Define guiding design principles
+- `opportunity-framework` — Prioritize design opportunities
+- `design-brief` — Write comprehensive design briefs
+- `stakeholder-alignment` — Create alignment artifacts
+- `metrics-definition` — Define UX metrics and KPIs
+
+**Commands:** `/strategize`, `/benchmark`, `/frame-problem`
+
+### Phase 3: Systems (design-systems)
+Establish tokens and components.
+- `component-spec` — Write component specifications
+- `design-token` — Define design tokens
+- `naming-convention` — Establish naming systems
+- `accessibility-audit` — Conduct WCAG audits
+- `documentation-template` — Structure documentation
+- `theming-system` — Design theming architectures
+- `pattern-library` — Structure pattern library entries
+- `icon-system` — Create icon system specifications
+
+**Commands:** `/audit-system`, `/create-component`, `/tokenize`
+
+### Phase 4: UI + Interaction (ui-design, interaction-design)
+Design screens and flows.
+- `color-system`, `layout-grid`, `typography-scale`, `spacing-system` — Visual foundations
+- `dark-mode-design`, `visual-hierarchy`, `responsive-design` — Adaptive design
+- `data-visualization`, `illustration-style` — Specialized visuals
+- `state-machine`, `micro-interaction-spec`, `animation-principles` — Interaction modeling
+- `gesture-patterns`, `feedback-patterns`, `error-handling-ux`, `loading-states` — Interaction patterns
+
+**Commands:** `/design-screen`, `/color-palette`, `/type-system`, `/responsive-audit`, `/design-interaction`, `/map-states`, `/error-flow`
+
+### Phase 5: Prototyping & Testing (prototyping-testing)
+Validate decisions.
+- `prototype-strategy` — Choose prototyping approach
+- `wireframe-spec` — Specify wireframe layouts
+- `heuristic-evaluation` — Conduct heuristic evaluations
+- `user-flow-diagram` — Create user flow diagrams
+- `test-scenario` — Write test scenarios
+- `accessibility-test-plan` — Plan accessibility testing
+- `a-b-test-design` — Design A/B experiments
+- `click-test-plan` — Design click tests
+
+**Commands:** `/prototype-plan`, `/evaluate`, `/test-plan`, `/experiment`
+
+### Phase 6: Ops & Delivery (design-ops, designer-toolkit)
+Handoff, rationale, documentation.
+- `handoff-spec`, `design-qa-checklist`, `design-review-process` — Delivery
+- `design-critique`, `design-sprint-plan`, `team-workflow` — Process
+- `version-control-strategy` — Version control
+- `design-rationale`, `ux-writing`, `presentation-deck`, `case-study` — Communication
+- `design-token-audit`, `design-system-adoption` — Maintenance
+
+**Commands:** `/plan-sprint`, `/handoff`, `/setup-workflow`, `/write-rationale`, `/build-presentation`, `/write-case-study`
+
+---
+
+## How to Route Design Work
+
+### Check for applicable skills before any design action
+When a user asks for design help, check if any of the 63 skills above apply. Even a 1% chance means you should load the skill to check.
+
+### For greenfield projects, use the `design-pipeline` skill
+Load the `design-pipeline` skill when starting from scratch. It walks through all 6 phases with quality gates between them.
+
+### For focused work, use individual skills directly
+A user asking "help me build a color palette" should trigger the `color-system` skill. No need for the full pipeline.
+
+### For multi-skill workflows, use commands
+Commands chain multiple skills together. For example, `/discover` chains user-persona, empathy-map, and journey-map into a research cycle.
+
+### Suggest next steps after completing work
+After finishing work in one phase, suggest relevant next phases or commands:
+- Research done? Suggest `/strategize` or `/frame-problem`
+- Strategy done? Suggest `/audit-system` or `/create-component`
+- Systems done? Suggest `/design-screen` or `/design-interaction`
+- Design done? Suggest `/evaluate` or `/prototype-plan`
+- Testing done? Suggest `/handoff` or address findings
+- Delivery done? Suggest `/write-case-study` or `/build-presentation`
+
+The natural flow is Research > Strategy > Systems > UI/Interaction > Testing > Delivery, but users can enter at any phase and skip phases that don't apply.
+
+## Red Flags
+
+These thoughts mean STOP — check for applicable skills:
+
+| Thought | Reality |
+|---------|---------|
+| "I can just answer this design question" | Load the relevant skill first — it has domain expertise you need |
+| "This is just a quick color question" | The `color-system` skill covers accessibility, semantics, and dark mode you'd miss |
+| "I don't need a skill for typography" | The `typography-scale` skill ensures modular scales and responsive behavior |
+| "Let me just sketch this interaction" | The `state-machine` and `micro-interaction-spec` skills prevent missed states |
+| "I'll wing the research" | The `user-persona` skill has structured methodology from Alan Cooper's work |


### PR DESCRIPTION
## Summary

Adds two new **workflow skills** that orchestrate the existing 63 domain skills into a coherent design pipeline, inspired by the [superpowers](https://github.com/obra/superpowers) plugin's approach to chaining skills through process workflows.

- **`using-designer-skills`** — Meta-skill providing session-level awareness of all 63 skills organized by 6 pipeline phases (Research → Strategy → Systems → UI/Interaction → Testing → Delivery). Includes routing logic and a red-flags table to prevent the agent from skipping applicable skills.
- **`design-pipeline`** — Process skill for greenfield projects that walks through all 6 phases with mandatory quality gates (user approval between each phase), a graphviz flowchart, and TodoWrite-based progress tracking.
- **`AGENTS.md`** — Persistent rules file describing the pipeline. Supported by Claude Code, OpenCode, and Codex as session context.

## Motivation

As discussed in [#1](https://github.com/Owl-Listener/designer-skills/issues/1), the existing skills work independently but lack guidance on sequencing for end-to-end projects. This adds the orchestration layer while keeping every existing skill unchanged.

## What's NOT changed

- All 63 existing SKILL.md files — untouched
- All 8 plugin configurations — untouched
- All 27 existing command files — untouched

## New files

```
workflow/skills/using-designer-skills/SKILL.md   (meta-skill)
workflow/skills/design-pipeline/SKILL.md         (pipeline process skill)
AGENTS.md                                        (persistent session context)
```