### PR TITLE
feat: add OpenCode support with plugin adapter and commands

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,0 +1,111 @@
+# Installing Designer Skills for OpenCode
+
+## Prerequisites
+
+- [OpenCode.ai](https://opencode.ai) installed
+
+## Installation
+
+Add designer-skills to the `plugin` array in your `opencode.json` (global or project-level):
+
+```json
+{
+  "plugin": ["designer-skills@git+https://github.com/Owl-Listener/designer-skills.git"]
+}
+```
+
+Restart OpenCode. The plugin auto-installs and registers all 63 design skills.
+
+Verify by asking: "What design skills do I have?"
+
+Or type `/` to see available design commands.
+
+## What Gets Installed
+
+The plugin registers:
+- **63 design skills** across 8 categories (research, strategy, systems, UI, interaction, testing, ops, toolkit)
+- **2 workflow skills** (`using-designer-skills` for pipeline awareness, `design-pipeline` for end-to-end projects)
+- **27 commands** for quick access to multi-skill workflows
+- **Session bootstrap** that makes every session aware of available design skills
+
+## Usage
+
+### Commands
+
+Type `/` in the TUI to see all available design commands:
+
+```
+/discover           - Full user research cycle
+/strategize         - Complete UX strategy
+/design-screen      - Design a screen layout
+/evaluate           - Heuristic evaluation
+/handoff            - Developer handoff package
+```
+
+### Skills
+
+Use OpenCode's native `skill` tool:
+
+```
+use skill tool to list skills
+use skill tool to load color-system
+use skill tool to load design-pipeline
+```
+
+### Full Pipeline
+
+For greenfield projects, ask the agent to use the `design-pipeline` skill:
+
+```
+I want to design a new feature from scratch. Use the design-pipeline skill.
+```
+
+This walks through Research > Strategy > Systems > Design > Validation > Delivery with quality gates.
+
+## Updating
+
+Designer Skills updates automatically when you restart OpenCode (re-fetched from git).
+
+To pin a specific version:
+
+```json
+{
+  "plugin": ["designer-skills@git+https://github.com/Owl-Listener/designer-skills.git#v1.0.0"]
+}
+```
+
+## How It Works
+
+The plugin does two things:
+
+1. **Registers all skill directories** via the `config` hook, so OpenCode discovers all 63+ skills without symlinks or manual config.
+2. **Injects pipeline awareness** via `experimental.chat.system.transform`, adding design skill awareness to every conversation.
+
+## Troubleshooting
+
+### Plugin not loading
+
+1. Check logs: `opencode run --print-logs "hello" 2>&1 | grep -i designer`
+2. Verify the plugin line in your `opencode.json`
+3. Make sure you're running a recent version of OpenCode
+
+### Skills not found
+
+1. Use the `skill` tool to list what's discovered
+2. Check that the plugin is loading (see above)
+3. Each skill needs a `SKILL.md` file with valid YAML frontmatter
+
+### Commands not showing
+
+1. Commands should appear when you type `/` in the TUI
+2. Verify `.opencode/commands/` directory exists in the installed plugin
+
+## Also Works With
+
+- **Claude Code**: Install via `/plugin marketplace add Owl-Listener/designer-skills`
+- **Codex**: Clone + run install script (see `.codex/INSTALL.md`)
+
+## Getting Help
+
+- Report issues: https://github.com/Owl-Listener/designer-skills/issues
+- Design philosophy: https://marieclairedean.substack.com/p/i-built-63-design-skills-for-claude

--- a/.opencode/commands/audit-system.md
+++ b/.opencode/commands/audit-system.md
@@ -1,0 +1,17 @@
+---
+description: Run a comprehensive audit of an existing design system for consistency, completeness, and accessibility
+---
+
+Run a comprehensive design system audit for $ARGUMENTS:
+
+1. **Inventory components and tokens** - Catalog all existing components using `component-spec` skill and tokens using `design-token` skill to establish a baseline
+2. **Check consistency** - Evaluate naming patterns across the system for coherence and predictability using `naming-convention` skill
+3. **Assess completeness** - Review documentation coverage and identify gaps using `documentation-template` skill
+4. **Audit accessibility** - Conduct a thorough accessibility audit against WCAG guidelines using `accessibility-audit` skill
+5. **Evaluate token coverage** - Analyze design token usage for consistency and coverage across the system using `design-token` skill
+6. **Review theming** - Assess theming architecture for dark mode, brand variants, and high-contrast support using `theming-system` skill
+7. **Generate report** - Compile findings into a prioritized audit report with severity ratings, gaps, and remediation recommendations
+
+Output: A comprehensive design system audit report covering component inventory, consistency analysis, documentation gaps, accessibility issues, token coverage, theming assessment, and a prioritized remediation roadmap.
+
+After completion, suggest next steps: `/create-component` to scaffold new components that address gaps, or `/tokenize` to extract and organize missing design tokens.

--- a/.opencode/commands/benchmark.md
+++ b/.opencode/commands/benchmark.md
@@ -1,0 +1,17 @@
+---
+description: Run a competitive benchmarking analysis across a set of products
+---
+
+Run a competitive benchmarking analysis for $ARGUMENTS:
+
+1. **Identify competitors** - Define the competitive set and categorize as direct, indirect, and aspirational competitors using `competitive-analysis` skill
+2. **Establish criteria** - Define benchmarking dimensions and measurable evaluation criteria using `metrics-definition` skill
+3. **Analyze each competitor** - Conduct detailed UX analysis of each competitor's patterns, features, strengths, and gaps using `competitive-analysis` skill
+4. **Compare journeys** - Map and compare user journeys across competitors to identify experience differentiators using `experience-map` skill
+5. **Score and rank** - Create a scoring matrix and rank competitors across all evaluation criteria
+6. **Identify opportunities** - Translate competitive gaps and differentiators into prioritized design opportunities using `opportunity-framework` skill
+7. **Generate report** - Compile findings into a comprehensive benchmarking report with visualizations and strategic recommendations
+
+Output: A competitive benchmarking report including competitor profiles, scoring matrix, journey comparisons, opportunity map, and strategic recommendations.
+
+After completion, suggest next steps: `/strategize` to develop a full UX strategy informed by benchmarking insights, or `/frame-problem` to define a specific design challenge targeting competitive gaps.

--- a/.opencode/commands/build-presentation.md
+++ b/.opencode/commands/build-presentation.md
@@ -1,0 +1,16 @@
+---
+description: Structure a design presentation for a specific audience
+---
+
+Structure a design presentation for $ARGUMENTS:
+
+1. **Analyze audience** - Identify the audience, their priorities, concerns, knowledge level, and what decisions they need to make
+2. **Build story arc** - Structure the presentation narrative with a compelling story arc using `presentation-deck` skill
+3. **Define key messages** - Distill the core messages and takeaways the audience should remember
+4. **Create slide outline** - Design the slide-by-slide outline with content, visuals, and speaker notes using `presentation-deck` skill
+5. **Add rationale slides** - Incorporate design rationale that connects decisions to evidence and principles using `design-rationale` skill
+6. **Review copy** - Polish all presentation copy for clarity, impact, and audience-appropriate tone using `ux-writing` skill
+
+Output: A complete presentation structure including audience analysis, story arc, key messages, detailed slide outline with speaker notes, rationale integration, and polished copy.
+
+After completion, suggest next steps: `/write-rationale` to develop more detailed design rationale documentation supporting the presentation.

--- a/.opencode/commands/color-palette.md
+++ b/.opencode/commands/color-palette.md
@@ -1,0 +1,16 @@
+---
+description: Generate a full color palette with semantic mapping and accessibility checks
+---
+
+Generate a full color palette for $ARGUMENTS:
+
+1. **Build base palette** - Generate a comprehensive color palette with primary, secondary, neutral, and accent scales using `color-system` skill
+2. **Create semantic mapping** - Map palette colors to semantic roles (success, warning, error, info, surface, text) using `color-system` skill
+3. **Check accessibility** - Verify all color combinations meet WCAG contrast requirements and document compliant pairings using `color-system` skill
+4. **Design dark mode palette** - Adapt the palette for dark mode with proper color inversion, contrast, and elevation cues using `dark-mode-design` skill
+5. **Define data visualization colors** - Create a distinct, accessible color set for charts and data visualization using `data-visualization` skill
+6. **Document the system** - Compile the complete color system with usage guidelines, do/don't examples, and implementation notes
+
+Output: A complete color system including base palette, semantic color mapping, accessibility compliance matrix, dark mode palette, data visualization colors, and usage documentation.
+
+After completion, suggest next steps: `/design-screen` to apply the color palette to a screen design, or `/type-system` to pair with a complementary typography system.

--- a/.opencode/commands/create-component.md
+++ b/.opencode/commands/create-component.md
@@ -1,0 +1,18 @@
+---
+description: Scaffold a full component specification from a name or description
+---
+
+Scaffold a full component specification for $ARGUMENTS:
+
+1. **Research** - Analyze existing patterns, prior art, and usage context for the component
+2. **Define anatomy** - Specify the component structure, props, slots, and composition using `component-spec` skill
+3. **Design variants** - Define all visual and behavioral variants with clear use cases
+4. **Specify states** - Document all interactive states (default, hover, focus, active, disabled, loading, error) using `component-spec` skill
+5. **Map tokens** - Assign design tokens for color, spacing, typography, and elevation using `design-token` skill
+6. **Ensure accessibility** - Define ARIA attributes, keyboard navigation, screen reader behavior, and WCAG compliance using `accessibility-audit` skill
+7. **Establish naming** - Apply consistent naming conventions for the component, its variants, and props using `naming-convention` skill
+8. **Write documentation** - Generate structured documentation with usage guidelines, do/don't examples, and code snippets using `documentation-template` skill
+
+Output: A complete component specification including anatomy, props API, variants, states, token mapping, accessibility requirements, naming conventions, and usage documentation.
+
+After completion, suggest next steps: `/audit-system` to verify the new component integrates well with the existing design system.

--- a/.opencode/commands/design-interaction.md
+++ b/.opencode/commands/design-interaction.md
@@ -1,0 +1,17 @@
+---
+description: Design a complete interaction flow for a feature or component
+---
+
+Design a complete interaction flow for $ARGUMENTS:
+
+1. **Model states** - Define all possible states and transitions as a finite state machine using `state-machine` skill
+2. **Specify micro-interactions** - Design micro-interactions with triggers, rules, feedback, and loops using `micro-interaction-spec` skill
+3. **Define animation** - Apply animation principles to transitions for purposeful, polished motion using `animation-principles` skill
+4. **Design gestures** - Specify gesture-based interactions for touch and pointer devices using `gesture-patterns` skill
+5. **Add feedback patterns** - Design system feedback for user actions including confirmations and status updates using `feedback-patterns` skill
+6. **Handle errors** - Design error prevention, detection, and recovery experiences using `error-handling-ux` skill
+7. **Design loading states** - Create loading, skeleton, and progressive content reveal patterns using `loading-states` skill
+
+Output: A complete interaction design specification including state machine diagram, micro-interaction specs, animation guidelines, gesture patterns, feedback design, error handling flows, and loading state patterns.
+
+After completion, suggest next steps: `/map-states` to deep-dive into complex state modeling, or `/error-flow` to design comprehensive error handling for the feature.

--- a/.opencode/commands/design-screen.md
+++ b/.opencode/commands/design-screen.md
@@ -1,0 +1,17 @@
+---
+description: Design a complete screen layout from a description or requirements
+---
+
+Design a complete screen layout for $ARGUMENTS:
+
+1. **Define structure** - Establish the layout grid with columns, gutters, margins, and breakpoint behavior using `layout-grid` skill
+2. **Establish hierarchy** - Design clear visual hierarchy through size, weight, color, spacing, and positioning using `visual-hierarchy` skill
+3. **Set typography** - Apply a modular typography scale with appropriate size, weight, and line-height relationships using `typography-scale` skill
+4. **Apply color** - Use the color system with semantic mapping and accessibility-compliant contrast ratios using `color-system` skill
+5. **Define spacing** - Apply consistent spacing using a systematic spacing scale with contextual rules using `spacing-system` skill
+6. **Design responsive behavior** - Specify adaptive layouts and interactions across all screen sizes and input methods using `responsive-design` skill
+7. **Add dark mode** - Design the dark mode variant with proper color adaptation, contrast, and elevation using `dark-mode-design` skill
+
+Output: A complete screen design specification including layout grid, visual hierarchy, typography, color application, spacing, responsive behavior across breakpoints, and dark mode variant.
+
+After completion, suggest next steps: `/responsive-audit` to verify responsive behavior across breakpoints, or `/design-interaction` to design interaction flows for the screen's components.

--- a/.opencode/commands/discover.md
+++ b/.opencode/commands/discover.md
@@ -1,0 +1,15 @@
+---
+description: Run a full user research cycle - persona creation, empathy mapping, and journey mapping
+---
+
+Run a full user research cycle for $ARGUMENTS:
+
+1. **Create user personas** - Synthesize available research data into detailed user personas using `user-persona` skill
+2. **Build empathy maps** - Create empathy maps (Says, Thinks, Does, Feels) for each persona using `empathy-map` skill
+3. **Map user journeys** - Map end-to-end user journeys with stages, touchpoints, emotions, and pain points using `journey-map` skill
+4. **Synthesize findings** - Cross-reference personas, empathy maps, and journeys to identify recurring themes, unmet needs, and opportunity areas
+5. **Suggest next steps** - Based on the research findings, recommend which follow-up activities would be most valuable
+
+Output: A comprehensive research package including user personas, empathy maps, journey maps, and a synthesis of key insights with prioritized opportunities.
+
+After completion, suggest next steps: `/interview` to prepare interview scripts for deeper exploration, `/research-test-plan` to design usability tests that validate findings, or `/strategize` to translate insights into UX strategy.

--- a/.opencode/commands/error-flow.md
+++ b/.opencode/commands/error-flow.md
@@ -1,0 +1,16 @@
+---
+description: Design a complete error handling flow for a feature
+---
+
+Design a complete error handling flow for $ARGUMENTS:
+
+1. **Identify error scenarios** - Catalog all possible error conditions, triggers, and severity levels using `error-handling-ux` skill
+2. **Design prevention** - Create safeguards, validation rules, and constraints that prevent errors before they occur using `error-handling-ux` skill
+3. **Model error states** - Map error conditions into the component state machine with transitions using `state-machine` skill
+4. **Define error feedback** - Design error messages, visual indicators, and notification patterns using `feedback-patterns` skill
+5. **Design recovery paths** - Create clear recovery flows that guide users back to a successful state using `error-handling-ux` skill
+6. **Handle loading failures** - Design patterns for network errors, timeouts, and partial loading failures using `loading-states` skill
+
+Output: A complete error handling specification including error catalog, prevention strategies, state machine integration, error feedback patterns, recovery flows, and loading failure handling.
+
+After completion, suggest next steps: `/map-states` to refine the overall state model incorporating error states.

--- a/.opencode/commands/evaluate.md
+++ b/.opencode/commands/evaluate.md
@@ -1,0 +1,16 @@
+---
+description: Run a heuristic evaluation of an existing design
+---
+
+Run a heuristic evaluation for $ARGUMENTS:
+
+1. **Define scope** - Establish the evaluation scope including screens, flows, and user scenarios to review
+2. **Conduct heuristic review** - Evaluate the design against Nielsen's heuristics and domain-specific criteria using `heuristic-evaluation` skill
+3. **Analyze user flows** - Review user flow paths for completeness, efficiency, and error-proneness using `user-flow-diagram` skill
+4. **Check accessibility** - Evaluate accessibility compliance against WCAG criteria and assistive technology support using `accessibility-test-plan` skill
+5. **Rate severity** - Assign severity ratings to each finding based on frequency, impact, and persistence
+6. **Generate recommendations** - Provide prioritized, actionable recommendations for each finding with suggested solutions
+
+Output: A heuristic evaluation report including findings organized by heuristic, flow analysis results, accessibility issues, severity ratings, and prioritized recommendations.
+
+After completion, suggest next steps: `/test-plan` to design usability tests that validate the most critical findings.

--- a/.opencode/commands/experiment.md
+++ b/.opencode/commands/experiment.md
@@ -1,0 +1,16 @@
+---
+description: Design an A/B experiment for a design hypothesis
+---
+
+Design an A/B experiment for $ARGUMENTS:
+
+1. **Formulate hypothesis** - Define a testable hypothesis with clear independent and dependent variables using `a-b-test-design` skill
+2. **Design variants** - Specify control and treatment variants with clear visual and behavioral differences
+3. **Define metrics** - Establish primary and secondary success metrics with measurement methods using `a-b-test-design` skill
+4. **Calculate sample size** - Determine required sample size for statistical significance using `a-b-test-design` skill
+5. **Map user flows** - Document the user flows for each variant to ensure consistent experience paths using `user-flow-diagram` skill
+6. **Plan analysis** - Define the statistical analysis approach, confidence thresholds, segmentation strategy, and decision framework
+
+Output: A complete A/B experiment design including hypothesis, variant specifications, metric definitions, sample size calculations, user flow diagrams, and analysis plan.
+
+After completion, suggest next steps: `/test-plan` to complement with qualitative usability testing alongside the experiment.

--- a/.opencode/commands/frame-problem.md
+++ b/.opencode/commands/frame-problem.md
@@ -1,0 +1,17 @@
+---
+description: Structure an ambiguous design challenge into a clear problem definition with constraints and criteria
+---
+
+Frame and structure a design challenge for $ARGUMENTS:
+
+1. **Explore the problem space** - Gather context, understand the domain, and map the boundaries of the challenge
+2. **Identify stakeholders** - Map stakeholder roles, interests, decision authority, and communication needs using `stakeholder-alignment` skill
+3. **Define the problem** - Write a clear problem definition with scope, audience, and desired outcomes using `design-brief` skill
+4. **Establish constraints** - Document technical, business, resource, and timeline constraints that bound the solution space
+5. **Set success criteria** - Define measurable success criteria and key performance indicators using `metrics-definition` skill
+6. **Align with principles** - Ensure the problem framing aligns with or establishes relevant design principles using `design-principles` skill
+7. **Prioritize focus areas** - Evaluate and prioritize sub-problems and opportunity areas using `opportunity-framework` skill
+
+Output: A structured problem definition including problem statement, stakeholder map, constraints inventory, success criteria, guiding principles, and prioritized focus areas.
+
+After completion, suggest next steps: `/strategize` to develop a full UX strategy around the framed problem, or `/benchmark` to understand how competitors address similar challenges.

--- a/.opencode/commands/handoff.md
+++ b/.opencode/commands/handoff.md
@@ -1,0 +1,16 @@
+---
+description: Generate a developer handoff package for a design
+---
+
+Generate a developer handoff package for $ARGUMENTS:
+
+1. **Document visual specs** - Create detailed visual specifications with measurements, colors, typography, and spacing using `handoff-spec` skill
+2. **Specify interactions** - Document interaction behaviors, animations, transitions, and edge cases using `handoff-spec` skill
+3. **Define QA criteria** - Create QA checklists for verifying design implementation accuracy using `design-qa-checklist` skill
+4. **Check review readiness** - Verify the handoff package meets design review gate criteria using `design-review-process` skill
+5. **Set up versioning** - Define version control strategy for design files and assets using `version-control-strategy` skill
+6. **Package deliverables** - Compile all specs, assets, annotations, and checklists into a complete handoff package
+
+Output: A complete developer handoff package including visual specifications, interaction specs, QA checklists, review approval, version control setup, and packaged deliverables.
+
+After completion, suggest next steps: `/setup-workflow` to establish ongoing design-development collaboration workflows.

--- a/.opencode/commands/interview.md
+++ b/.opencode/commands/interview.md
@@ -1,0 +1,17 @@
+---
+description: Prepare an interview script or summarize an interview transcript into structured insights
+---
+
+Prepare an interview script or summarize an interview transcript for $ARGUMENTS:
+
+If **preparing** for interviews:
+1. **Create interview script** - Design a structured interview script with warm-up, core exploration, and wrap-up sections using `interview-script` skill
+2. **Review and refine** - Ensure questions are open-ended, non-leading, and aligned to research objectives
+
+If **summarizing** a transcript:
+1. **Summarize transcript** - Extract structured insights with key themes, quotes, and action items using `summarize-interview` skill
+2. **Identify patterns** - Highlight recurring themes, surprising findings, and areas needing further exploration
+
+Output: Either a ready-to-use interview script with facilitation notes, or a structured interview summary with key themes, notable quotes, and recommended action items.
+
+After completion, suggest next steps: `/synthesize` to combine insights from multiple interviews into affinity diagrams, or `/discover` to run a full research cycle building on interview findings.

--- a/.opencode/commands/map-states.md
+++ b/.opencode/commands/map-states.md
@@ -1,0 +1,16 @@
+---
+description: Model the states and transitions for a complex UI component
+---
+
+Model the states and transitions for $ARGUMENTS:
+
+1. **Identify states** - Enumerate all possible states the component can be in using `state-machine` skill
+2. **Map transitions** - Define events, guards, and actions for each state transition using `state-machine` skill
+3. **Design loading states** - Specify loading, skeleton, and progressive reveal patterns for async states using `loading-states` skill
+4. **Define error states** - Model error conditions, their visual representation, and recovery paths using `error-handling-ux` skill
+5. **Add feedback** - Design feedback for each state change including visual, auditory, and haptic cues using `feedback-patterns` skill
+6. **Specify animation** - Define transition animations between states with timing and easing using `animation-principles` skill
+
+Output: A complete state model including state diagram, transition table, loading state patterns, error state definitions, feedback specifications, and transition animations.
+
+After completion, suggest next steps: `/design-interaction` to design the full interaction flow around this state model.

--- a/.opencode/commands/plan-sprint.md
+++ b/.opencode/commands/plan-sprint.md
@@ -1,0 +1,16 @@
+---
+description: Plan a design sprint for a specific challenge
+---
+
+Plan a design sprint for $ARGUMENTS:
+
+1. **Frame the challenge** - Define the sprint challenge, scope, and desired outcomes using `design-sprint-plan` skill
+2. **Assemble the team** - Define team roles, responsibilities, and collaboration workflows using `team-workflow` skill
+3. **Plan activities** - Structure the sprint schedule with activities for each day/phase using `design-sprint-plan` skill
+4. **Prepare materials** - List required materials, templates, tools, and preparation tasks for each activity
+5. **Recruit testers** - Define participant criteria, recruitment plan, and scheduling for prototype testing
+6. **Set review criteria** - Establish review gates and evaluation criteria for sprint outputs using `design-review-process` skill
+
+Output: A complete design sprint plan including challenge statement, team roster, day-by-day activity schedule, materials checklist, tester recruitment plan, and review criteria.
+
+After completion, suggest next steps: `/handoff` to create developer handoff packages for sprint outputs.

--- a/.opencode/commands/prototype-plan.md
+++ b/.opencode/commands/prototype-plan.md
@@ -1,0 +1,16 @@
+---
+description: Create a prototyping and testing plan for a design initiative
+---
+
+Create a prototyping and testing plan for $ARGUMENTS:
+
+1. **Define strategy** - Choose the right prototyping fidelity and method for the design questions to answer using `prototype-strategy` skill
+2. **Map user flows** - Create user flow diagrams showing paths, decisions, and branch logic to prototype using `user-flow-diagram` skill
+3. **Specify wireframes** - Define wireframe layouts with content priority, component placement, and annotations using `wireframe-spec` skill
+4. **Write test scenarios** - Create usability test scenarios with tasks, success criteria, and observation guides using `test-scenario` skill
+5. **Plan accessibility testing** - Create an accessibility testing plan covering assistive technologies and WCAG criteria using `accessibility-test-plan` skill
+6. **Set timeline** - Define milestones, review checkpoints, and delivery schedule for the prototype-test cycle
+
+Output: A complete prototyping and testing plan including fidelity rationale, user flows, wireframe specs, test scenarios, accessibility test plan, and project timeline.
+
+After completion, suggest next steps: `/test-plan` to expand into a full usability testing plan, or `/evaluate` to run a heuristic evaluation of the prototype.

--- a/.opencode/commands/research-test-plan.md
+++ b/.opencode/commands/research-test-plan.md
@@ -1,0 +1,14 @@
+---
+description: Design a usability test plan with tasks, metrics, participant criteria, and facilitation guide
+---
+
+Design a usability test plan for $ARGUMENTS:
+
+1. **Design test plan** - Create a comprehensive usability test plan with objectives, tasks, success metrics, participant criteria, and facilitation guide using `usability-test-plan` skill
+2. **Align to personas** - Map test participants and scenarios to existing user personas to ensure representative coverage
+3. **Create pilot checklist** - Develop a pre-test pilot checklist covering technology setup, script walkthrough, timing estimates, and contingency plans
+4. **Finalize logistics** - Define recruitment criteria, scheduling, compensation, and data collection methods
+
+Output: A complete usability test plan including task scenarios, success metrics, participant screener, facilitation script, pilot checklist, and logistics plan.
+
+After completion, suggest next steps: `/synthesize` to analyze test results into structured insights, or `/interview` to prepare follow-up interview scripts for deeper exploration of test findings.

--- a/.opencode/commands/responsive-audit.md
+++ b/.opencode/commands/responsive-audit.md
@@ -1,0 +1,17 @@
+---
+description: Audit a design for responsive behavior across breakpoints
+---
+
+Audit responsive behavior across breakpoints for $ARGUMENTS:
+
+1. **Review breakpoints** - Evaluate breakpoint definitions and verify they cover all target devices and use cases using `responsive-design` skill
+2. **Audit grid behavior** - Check layout grid adaptation across breakpoints including column count, gutter, and margin changes using `layout-grid` skill
+3. **Check typography scaling** - Verify typography scale adjustments across breakpoints for readability and hierarchy using `typography-scale` skill
+4. **Evaluate spacing** - Assess spacing system behavior at each breakpoint for consistency and appropriate density using `spacing-system` skill
+5. **Verify visual hierarchy** - Confirm visual hierarchy is maintained across screen sizes with appropriate content prioritization using `visual-hierarchy` skill
+6. **Assess touch targets** - Verify interactive element sizing meets minimum touch target requirements across devices using `responsive-design` skill
+7. **Generate report** - Compile findings into a responsive audit report with issues, severity ratings, and recommendations
+
+Output: A responsive audit report covering breakpoint analysis, grid behavior, typography scaling, spacing evaluation, hierarchy verification, touch target compliance, and prioritized remediation recommendations.
+
+After completion, suggest next steps: `/design-screen` to redesign screens that failed the audit.

--- a/.opencode/commands/setup-workflow.md
+++ b/.opencode/commands/setup-workflow.md
@@ -1,0 +1,16 @@
+---
+description: Set up a design team workflow and rituals
+---
+
+Set up a design team workflow for $ARGUMENTS:
+
+1. **Define team structure** - Establish team roles, responsibilities, and collaboration models using `team-workflow` skill
+2. **Design rituals** - Set up recurring team rituals including standups, syncs, and retrospectives using `team-workflow` skill
+3. **Establish critique process** - Define structured design critique frameworks and feedback protocols using `design-critique` skill
+4. **Set review gates** - Create design review checkpoints with criteria, checklists, and approval workflows using `design-review-process` skill
+5. **Configure versioning** - Define version control strategies for design files, components, and libraries using `version-control-strategy` skill
+6. **Create QA process** - Establish design QA checklists and verification procedures for implementation using `design-qa-checklist` skill
+
+Output: A complete team workflow specification including team structure, ritual calendar, critique framework, review gates, version control strategy, and QA process.
+
+After completion, suggest next steps: `/plan-sprint` to plan a design sprint using the established workflow.

--- a/.opencode/commands/strategize.md
+++ b/.opencode/commands/strategize.md
@@ -1,0 +1,17 @@
+---
+description: Develop a complete UX strategy with vision, competitive analysis, principles, and design brief
+---
+
+Develop a complete UX strategy for $ARGUMENTS:
+
+1. **Articulate vision** - Define a compelling north-star product vision that aligns teams and inspires direction using `north-star-vision` skill
+2. **Analyze landscape** - Conduct a structured competitive analysis comparing UX patterns, features, and gaps using `competitive-analysis` skill
+3. **Map experience ecosystem** - Create a holistic experience map showing touchpoints, channels, and relationships using `experience-map` skill
+4. **Define principles** - Establish actionable design principles that guide decision-making and resolve trade-offs using `design-principles` skill
+5. **Identify opportunities** - Evaluate and prioritize design opportunities using impact-effort frameworks using `opportunity-framework` skill
+6. **Define metrics** - Establish UX metrics and KPIs connecting design decisions to measurable outcomes using `metrics-definition` skill
+7. **Write design brief** - Compile everything into a comprehensive design brief defining problem space, constraints, and success criteria using `design-brief` skill
+
+Output: A complete UX strategy package including north-star vision, competitive analysis, experience map, design principles, prioritized opportunities, success metrics, and a design brief.
+
+After completion, suggest next steps: `/benchmark` to deep-dive into competitive positioning, or `/frame-problem` to sharpen a specific design challenge within the strategy.

--- a/.opencode/commands/synthesize.md
+++ b/.opencode/commands/synthesize.md
@@ -1,0 +1,15 @@
+---
+description: Synthesize research data into affinity diagrams, themes, and actionable insights
+---
+
+Synthesize research data into actionable insights for $ARGUMENTS:
+
+1. **Build affinity diagram** - Organize qualitative research data into clusters and themes using `affinity-diagram` skill
+2. **Map jobs-to-be-done** - Frame findings as user jobs with functional, emotional, and social dimensions using `jobs-to-be-done` skill
+3. **Combine and triangulate** - Cross-reference affinity clusters with JTBD to identify convergent insights, validate themes across data sources, and surface hidden patterns
+4. **Prioritize insights** - Rank insights by frequency, impact, and actionability
+5. **Generate recommendations** - Translate insights into concrete design implications and opportunity areas
+
+Output: A research synthesis including an affinity diagram with themed clusters, a JTBD framework, prioritized insight statements, and actionable design recommendations.
+
+After completion, suggest next steps: `/discover` to deepen understanding with additional persona and journey work, or `/research-test-plan` to design tests that validate key insights.

--- a/.opencode/commands/test-plan.md
+++ b/.opencode/commands/test-plan.md
@@ -1,0 +1,16 @@
+---
+description: Design a complete usability testing plan with scenarios and accessibility coverage
+---
+
+Design a complete usability testing plan for $ARGUMENTS:
+
+1. **Define objectives** - Establish research questions, learning goals, and scope for the testing round
+2. **Select method** - Choose the appropriate testing method and fidelity based on the design questions using `prototype-strategy` skill
+3. **Write test scenarios** - Create detailed test scenarios with tasks, success criteria, and observation guides using `test-scenario` skill
+4. **Design click tests** - Plan click/first-click tests to evaluate navigation and information findability using `click-test-plan` skill
+5. **Plan accessibility testing** - Define accessibility testing coverage for assistive technologies and WCAG criteria using `accessibility-test-plan` skill
+6. **Arrange logistics** - Define participant recruitment, scheduling, environment setup, recording, and data collection procedures
+
+Output: A complete usability testing plan including objectives, method rationale, test scenarios, click test designs, accessibility testing plan, and logistics checklist.
+
+After completion, suggest next steps: `/evaluate` to complement with expert heuristic evaluation.

--- a/.opencode/commands/tokenize.md
+++ b/.opencode/commands/tokenize.md
@@ -1,0 +1,17 @@
+---
+description: Extract and organize design tokens from an existing design or stylesheet
+---
+
+Extract and organize design tokens for $ARGUMENTS:
+
+1. **Extract raw values** - Identify all color, spacing, typography, elevation, and other design values from the source material
+2. **Deduplicate and normalize** - Remove duplicates, resolve near-duplicates, and normalize values into a consistent format using `design-token` skill
+3. **Categorize tokens** - Organize tokens into categories (color, spacing, typography, elevation, motion, breakpoints) with clear boundaries
+4. **Build hierarchy** - Structure tokens into a three-tier hierarchy (global/primitive, semantic/alias, component-specific) using `design-token` skill
+5. **Apply naming conventions** - Establish consistent, predictable token names following a systematic naming convention using `naming-convention` skill
+6. **Define theme mappings** - Map tokens across themes (light, dark, high-contrast, brand variants) using `theming-system` skill
+7. **Document token system** - Generate comprehensive token documentation with usage guidance, examples, and migration notes using `documentation-template` skill
+
+Output: A complete design token system including categorized tokens, naming conventions, theme mappings, hierarchy structure, and usage documentation.
+
+After completion, suggest next steps: `/audit-system` to verify token coverage and consistency across the design system.

--- a/.opencode/commands/type-system.md
+++ b/.opencode/commands/type-system.md
@@ -1,0 +1,16 @@
+---
+description: Create a complete typography system from brand fonts or requirements
+---
+
+Create a complete typography system for $ARGUMENTS:
+
+1. **Build type scale** - Create a modular typography scale with size, weight, and line-height relationships using `typography-scale` skill
+2. **Establish hierarchy** - Define typographic hierarchy for headings, body, captions, and UI text using `visual-hierarchy` skill
+3. **Design responsive behavior** - Specify how typography scales and adapts across breakpoints and screen sizes using `responsive-design` skill
+4. **Integrate spacing** - Define vertical rhythm and spacing rules that align typography with the spacing system using `spacing-system` skill
+5. **Align to grid** - Ensure type sizes and line-heights align to the baseline grid and layout grid using `layout-grid` skill
+6. **Document the system** - Compile the complete typography system with usage guidelines, pairing rules, and implementation specs
+
+Output: A complete typography system including modular scale, hierarchy definitions, responsive behavior, spacing integration, grid alignment, and usage documentation.
+
+After completion, suggest next steps: `/design-screen` to apply the typography system to a screen design, or `/color-palette` to pair with a complementary color system.

--- a/.opencode/commands/write-case-study.md
+++ b/.opencode/commands/write-case-study.md
@@ -1,0 +1,16 @@
+---
+description: Create a portfolio case study from a project summary
+---
+
+Create a portfolio case study for $ARGUMENTS:
+
+1. **Build outline** - Structure the case study narrative with sections and flow using `case-study` skill
+2. **Write the challenge** - Articulate the problem, context, constraints, and goals that framed the project
+3. **Document the process** - Describe the design process, methodology, and key decisions with rationale using `design-rationale` skill
+4. **Present the solution** - Showcase the final design with key features, interactions, and design system decisions
+5. **Demonstrate impact** - Quantify results with metrics, user feedback, and business outcomes
+6. **Polish copy** - Review and refine all copy for storytelling quality, clarity, and professional tone using `ux-writing` skill
+
+Output: A portfolio-ready case study including structured narrative, challenge framing, process documentation, solution showcase, impact metrics, and polished copy.
+
+After completion, suggest next steps: `/build-presentation` to create a presentation version of the case study for stakeholders or interviews.

--- a/.opencode/commands/write-rationale.md
+++ b/.opencode/commands/write-rationale.md
@@ -1,0 +1,16 @@
+---
+description: Write design rationale for a set of design decisions
+---
+
+Write design rationale for $ARGUMENTS:
+
+1. **Identify decisions** - Catalog the key design decisions that need rationale documentation using `design-rationale` skill
+2. **Gather evidence** - Collect supporting evidence from research, data, principles, and constraints for each decision
+3. **Document alternatives** - Record alternatives considered for each decision and why they were not chosen
+4. **Write rationale** - Write clear rationale connecting each decision to user needs, business goals, and design principles using `design-rationale` skill
+5. **Review copy** - Polish the rationale text for clarity, tone, and persuasiveness using `ux-writing` skill
+6. **Package documentation** - Organize rationale documents for easy reference and stakeholder consumption
+
+Output: A comprehensive design rationale document including decision inventory, supporting evidence, alternatives analysis, written rationale for each decision, and polished documentation.
+
+After completion, suggest next steps: `/build-presentation` to create a presentation that communicates the design rationale to stakeholders.

--- a/.opencode/plugins/designer-skills.js
+++ b/.opencode/plugins/designer-skills.js
@@ -1,0 +1,90 @@
+/**
+ * Designer Skills plugin for OpenCode.ai
+ *
+ * Registers all design skill directories so OpenCode discovers them
+ * without symlinks or manual config. Injects pipeline awareness via
+ * system prompt transform.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+
+// Simple frontmatter extraction (no external deps needed for bootstrap)
+const extractAndStripFrontmatter = (content) => {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, content };
+
+  const frontmatterStr = match[1];
+  const body = match[2];
+  const frontmatter = {};
+
+  for (const line of frontmatterStr.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, '');
+      frontmatter[key] = value;
+    }
+  }
+
+  return { frontmatter, content: body };
+};
+
+// All skill directories in the repo
+const SKILL_DIRS = [
+  'design-research/skills',
+  'design-systems/skills',
+  'ux-strategy/skills',
+  'ui-design/skills',
+  'interaction-design/skills',
+  'prototyping-testing/skills',
+  'design-ops/skills',
+  'designer-toolkit/skills',
+  'workflow/skills',
+];
+
+export const DesignerSkillsPlugin = async ({ client, directory }) => {
+
+  const getBootstrapContent = () => {
+    const skillPath = path.join(repoRoot, 'workflow', 'skills', 'using-designer-skills', 'SKILL.md');
+    if (!fs.existsSync(skillPath)) return null;
+
+    const fullContent = fs.readFileSync(skillPath, 'utf8');
+    const { content } = extractAndStripFrontmatter(fullContent);
+
+    return `<DESIGNER_SKILLS>
+You have designer skills — a comprehensive collection of 63 design skills for product designers.
+
+**IMPORTANT: The using-designer-skills skill content is included below. It is ALREADY LOADED — do NOT use the skill tool to load "using-designer-skills" again.**
+
+${content}
+</DESIGNER_SKILLS>`;
+  };
+
+  return {
+    // Register all skill directories so OpenCode discovers them automatically
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+
+      for (const dir of SKILL_DIRS) {
+        const fullPath = path.resolve(repoRoot, dir);
+        if (fs.existsSync(fullPath) && !config.skills.paths.includes(fullPath)) {
+          config.skills.paths.push(fullPath);
+        }
+      }
+    },
+
+    // Inject pipeline awareness into every session
+    'experimental.chat.system.transform': async (_input, output) => {
+      const bootstrap = getBootstrapContent();
+      if (bootstrap) {
+        (output.system ||= []).push(bootstrap);
+      }
+    }
+  };
+};


### PR DESCRIPTION
## Summary

Adds native [OpenCode.ai](https://opencode.ai) support so all 63 design skills and 27 commands work in OpenCode without manual configuration.

- **Plugin adapter** (`.opencode/plugins/designer-skills.js`) — Registers all skill directories via the `config` hook and injects pipeline awareness via `experimental.chat.system.transform`. Modeled on the [superpowers](https://github.com/obra/superpowers) OpenCode adapter.
- **27 flattened commands** (`.opencode/commands/*.md`) — Converted from Claude Code's namespaced `/plugin:command` format to OpenCode's flat `/command` format. One naming conflict resolved: `research-test-plan` (research-focused) vs `test-plan` (prototyping-focused).
- **Installation docs** (`.opencode/INSTALL.md`) — Setup, usage, troubleshooting.

## Installation

```json
{
  "plugin": ["designer-skills@git+https://github.com/Owl-Listener/designer-skills.git"]
}
```

## What's NOT changed

- All 63 existing SKILL.md files — untouched
- All Claude Code configs and commands — untouched

## New files

```
.opencode/plugins/designer-skills.js    (plugin adapter)
.opencode/commands/*.md                  (27 command files)
.opencode/INSTALL.md                     (installation docs)
```

## Notes

The plugin adapter gracefully degrades if the workflow skills (from the separate workflow-skills PR) are not yet present — skill registration and commands work independently of the bootstrap injection.