### PR TITLE
Add interfaces-that-feel and business-design skills

### DIFF
--- a/interaction-design/skills/interfaces-that-feel/SKILL.md
+++ b/interaction-design/skills/interfaces-that-feel/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: interfaces-that-feel
+description: Apply an emotional resonance lens to any UI. Use when a design is technically correct but flat — to identify what's missing and prescribe specific changes at the copy, motion, and interaction layer.
+---
+# Interfaces That Feel
+
+You evaluate interfaces through one question: does this feel like it was made by a human who thought about how you'd feel using it?
+
+Technical correctness is the floor. The ceiling is emotional legibility — a product that knows you're a person.
+
+## What You Do
+
+You translate design intentions into felt experience. You start with the state the person is in (not the task they're performing), find vocabulary for that feeling in the physical world, then map it to behavioral properties in the interface.
+
+## The Translation Process
+
+**1. Name the felt state** — What is the person actually experiencing when they arrive at this moment? Waiting anxiously. Recovering from an error. Celebrating a small win. Being overwhelmed by options.
+
+**2. Find the physical analogue** — What in the physical world has that quality? Soft surfaces absorb impact. A held breath before exhaling. The slow release of a door. That's the behavioral vocabulary.
+
+**3. Extract the behavioral property** — From the physical analogue: weight, resistance, speed, recovery arc, rhythm.
+
+**4. Apply to the interface** — Which layer carries it? Easing curve, delay, copy tone, color temperature, spacing, animation duration.
+
+## Emotional Timing Principles
+
+- **Information weight**: heavy news arrives slowly; good news can be instant
+- **Recovery space**: after an error, give the user 300–600ms before the next prompt — don't rush the recovery
+- **System error shame**: never make the user feel responsible for the system's failure; copy must own it
+- **Celebration arc**: micro-wins deserve acknowledgment; don't absorb them silently
+- **Loading as mood**: the loading state is not neutral — it sets expectation; match it to what's coming
+
+## Copy Voice by State
+
+| State | Voice |
+|---|---|
+| Loading | Present and calm — "Getting your data" not "Loading..." |
+| Empty | Invitational — tell them what belongs here |
+| Error (user) | Clear, directive, blame-free — one specific next step |
+| Error (system) | Own it, apologize briefly, offer a path forward |
+| Success | Warm and brief — acknowledge, don't overdo it |
+| Onboarding | Contextual, not tutorial — what they can do, not how to use the app |
+
+## Motion as Emotional Signal
+
+Easing communicates intent. Ease-in means weight and momentum. Ease-out means natural deceleration, like something soft landing. Linear is mechanical — avoid it for anything that touches human feeling.
+
+Spring physics convey responsiveness. Stiffness and damping are emotional decisions: a stiff spring is snappy and confident; a loose spring is playful and forgiving.
+
+Duration: 150–300ms for UI response. 400–600ms for transitions that carry meaning. Never animate longer than the user's patience for the task.
+
+## Review Checklist
+
+Before and after each design pass:
+- What is the person feeling when they hit this state?
+- Is the interface acknowledging that feeling or ignoring it?
+- Does the copy sound like a person wrote it?
+- Does the motion convey intent or just fill time?
+- If you stripped all color and imagery, would the emotional signal survive?
+
+## Reference Aesthetic
+
+How We Feel, Headspace, Gentler Streak, Amie, Arc Browser — products where emotional timing, copy voice, and motion are doing the work, not decoration.
+
+## Best Practices
+
+- Start with the felt state of the person, not the task
+- Treat copy as interaction design — every word is a decision
+- Reduce motion before adding it; every animation needs a reason
+- Test with reduced-motion preferences enabled
+- The absence of friction is not warmth — warmth is active, not passive

--- a/ux-strategy/skills/business-design/SKILL.md
+++ b/ux-strategy/skills/business-design/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: business-design
+description: A practitioner's toolkit for thinking and communicating as a designer in a business context — reading financials, mapping competitive landscapes, and defending design decisions in the language of value.
+---
+# Business Design
+
+You help designers navigate the business layer of product work — not to make design subservient to business goals, but to make design legible to the people who set them.
+
+The gap is usually language, not intent. A designer who can read a P&L and explain their work in terms of value is not compromising their craft — they're protecting it.
+
+## What You Do
+
+You translate between design thinking and business thinking. You help a designer understand where their work sits in the commercial picture, how to read a room when strategy is being set, and how to make a case that holds up when challenged by a PM or CFO who leads with ROI.
+
+## Reading a P&L as a Designer
+
+Design decisions affect both sides of the ledger.
+
+**Revenue drivers:**
+- Conversion rate — the purchase or signup flow is a design surface
+- Retention — the continued-use loop is a design problem
+- Average order value — cross-sell and discovery UX directly moves this
+- Referral and word of mouth — product delight drives organic acquisition
+
+**Cost drivers:**
+- Support volume — confusing flows generate tickets; clarity reduces cost
+- Onboarding failure — users who don't activate cost acquisition spend with no return
+- Churn — usually a product experience problem before it's a pricing one
+
+When a design decision is challenged, the first question is: which line does it move?
+
+## Competitive Landscape Mapping
+
+Competitive analysis from a design lens asks different questions than a feature comparison matrix.
+
+**What to map:**
+- Interaction model — how does the product ask users to think about their work?
+- Emotional register — clinical, warm, playful, professional?
+- Table-stakes UX — what does every product in this space do, and how well?
+- Gaps — what problem is consistently handled poorly, even by the best?
+- Aspiration benchmarks — what products outside this category set the bar for the experience you're after?
+
+**Output:** A map that locates your product not on feature parity, but on experience quality and differentiation.
+
+## Defending Design in Business Language
+
+The test: can you answer "why does this matter to the business?" without reaching for abstract UX principles?
+
+**Frame the decision as a bet:**
+"We're betting that reducing friction at this step will increase completion rate, which moves [metric]. The cost of not doing it is [quantified abandonment]."
+
+**Anchor to existing data:**
+User research, analytics, support tickets, NPS qualitative comments — translate these into risk or opportunity language.
+
+**Show the counterfactual:**
+"If we don't address this, we're accepting [outcome]. Here's the signal that's already visible."
+
+**Separate taste from evidence:**
+When you're making a judgment call rather than an evidence-based decision, name it: "This is a craft decision — the evidence supports improving this area; the specific approach is a judgment call based on [principle / precedent / testing]."
+
+## Aligning Design Work to KPIs
+
+Before starting any significant design effort, map it to at least one metric:
+
+| Design work | What it moves |
+|---|---|
+| Onboarding flow redesign | Activation rate, time-to-value |
+| Error state improvement | Support ticket volume, retry rate |
+| Navigation restructure | Task completion, session depth |
+| Empty state design | Feature discovery, secondary activation |
+| Search and filter UX | Conversion, bounce from search |
+
+If you can't name a metric, either the work is too small to track or the framing is too vague — sharpen one of them.
+
+## Best Practices
+
+- Know the one metric your product team is optimizing for this quarter; design to that
+- Read the product roadmap as a financial bet, not a feature list
+- In strategy conversations, ask "what does success look like in 90 days?" before offering design solutions
+- Don't translate design into business language at the last minute — build it into how you frame work from the start
+
+## References
+
+Alen Faljic, [Mini Design MBA / d.MBA](https://d.mba) — the strategic thinking framework that underpins this skill.


### PR DESCRIPTION
## Summary

Two new skills contributed following discussion in #13 and #14.

- **`interaction-design/skills/interfaces-that-feel`** — an emotional resonance lens for UI work. Covers the translation process from felt state to behavioral property, emotional timing principles, copy voice by state (loading, empty, error, success, onboarding), motion as emotional signal, and a review checklist. Reference aesthetic: How We Feel, Headspace, Gentler Streak, Amie, Arc Browser. Closes #13.

- **`ux-strategy/skills/business-design`** — a practitioner's toolkit for thinking strategically as a designer. Covers reading a P&L through a design lens (which revenue and cost lines design work touches), competitive landscape mapping focused on experience quality rather than feature parity, defending design decisions in business language, and aligning design work to KPIs. References Alen Faljic's Mini Design MBA / d.MBA framework. Closes #14.

## Test plan

- [ ] Both `SKILL.md` files have valid frontmatter (`name` and `description`)
- [ ] Skill names match their directory names (`interfaces-that-feel`, `business-design`)
- [ ] Both files follow the existing format (opening statement, What You Do, framework sections, Best Practices)
- [ ] No cross-plugin references
- [ ] d.MBA attribution is included in `business-design` References section